### PR TITLE
[Agent] Fix: Supabase URL pointing to wrong project

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://wrongproject.supabase.co";
+const SUPABASE_URL = "https://lrqnbomzumuudilijhve.supabase.co";
 const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxycW5ib216dW11dWRpbGlqaHZlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTYxOTEyMDMsImV4cCI6MjA3MTc2NzIwM30.rMulUbaTMYSrABZogcoTqWyIfk8tr_UpeScXx8X_wLE";
 
 // Import the supabase client like this:


### PR DESCRIPTION
## [Agent] Fix

**Issue:** Supabase URL in `src/integrations/supabase/client.ts` is set to `https://wrongproject.supabase.co` instead of the correct project URL.
**Reported by:** @Gautham248
**Environment:** Production

---

**Root cause / Change made:** Commit `b4ff770` ("bug: wrong Supabase URL (edge case test)") reintroduced the wrong URL as an intentional test bug. Reverted to the correct URL `https://lrqnbomzumuudilijhve.supabase.co` found in git history (commit `c6f771b`).

**File changed:** `src/integrations/supabase/client.ts`
**Files read but not changed:** none

**Confidence:** High — single-line constant change, verified against git history.

---
> ⚠️ This PR was opened by an AI agent. Please review carefully before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect backend service configuration URL to ensure proper connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->